### PR TITLE
Added so PUM can handle illegal argument and únit test related to that.

### DIFF
--- a/src/Main.java
+++ b/src/Main.java
@@ -22,14 +22,13 @@ public class Main {
         }
     }
 
-
     // INPUT VARIABLES
-    public static int NUMPOINTS;  // The number of planar data points
+    public static int NUMPOINTS; // The number of planar data points
     public static double[] POINTS; // Array containing the coordinates of data points
     public static CONNECTORS[][] LCM = new CONNECTORS[15][15]; // Logical connector Matrix
     public static boolean[] PUV = new boolean[NUMPOINTS]; // Preliminary Unlocking Vector
 
-    // PARAMETERS = 0;  // Parameters for LIC, fix later
+    // PARAMETERS = 0; // Parameters for LIC, fix later
 
     // OUTPUT VARIABLE
     public static boolean DECIDE() {
@@ -45,44 +44,53 @@ public class Main {
         return false;
     }
 
-      
-      public static boolean[] CMV() {
-        boolean[] CMV = new boolean[15];
-        ConditionsMet conditionsMet = new ConditionsMet();
-
-        for (int i = 0; i <= 14; i++) {
-            CMV[i] = conditionsMet().condition(i);
-        }
-      
-      return CMV;
-      }
+    /*
+     * public static boolean[] CMV() {
+     * boolean[] CMV = new boolean[15];
+     * ConditionsMet conditionsMet = new ConditionsMet();
+     * 
+     * for (int i = 0; i <= 14; i++) {
+     * CMV[i] = conditionsMet().condition(i);
+     * }
+     * 
+     * return CMV;
+     * }
+     */
 
     public static boolean[][] PUM(CONNECTORS[][] LCM, boolean[] CMV) {
 
         int n = CMV.length;
         boolean[][] PUM_matrix = new boolean[n][n];
 
-        for (int i = 0; i < n; i++) {
+        if (n == LCM[0].length && n == LCM[1].length) {
 
-            for (int j = 0; j < n; j++) {
+            for (int i = 0; i < n; i++) {
 
-                if (LCM[i][j] == CONNECTORS.NOTUSED) {
-                    PUM_matrix[i][j] = true;
-                }
+                for (int j = 0; j < n; j++) {
 
-                else if (LCM[i][j] == CONNECTORS.ANDD) {
-                    if (CMV[i] == true && CMV[j] == true) {
+                    if (LCM[i][j] == CONNECTORS.NOTUSED) {
                         PUM_matrix[i][j] = true;
                     }
-                }
 
-                else if (LCM[i][j] == CONNECTORS.ORR) {
-                    if (CMV[i] == true || CMV[j] == true) {
-                        PUM_matrix[i][j] = true;
+                    else if (LCM[i][j] == CONNECTORS.ANDD) {
+                        if (CMV[i] == true && CMV[j] == true) {
+                            PUM_matrix[i][j] = true;
+                        }
                     }
-                }
 
+                    else if (LCM[i][j] == CONNECTORS.ORR) {
+                        if (CMV[i] == true || CMV[j] == true) {
+                            PUM_matrix[i][j] = true;
+                        }
+                    }
+
+                }
             }
+
+        }
+
+        else {
+            throw new IllegalArgumentException("The LCM should be a n x n vector, where n is the length of CMV");
         }
 
         return PUM_matrix;

--- a/test/Testfile.java
+++ b/test/Testfile.java
@@ -2,43 +2,64 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
 public class Testfile {
-    @Test
-    public void testPUMmixedConnectors() {
+        @Test
+        public void testPUMmixedConnectors() {
 
-        Main.CONNECTORS[][] LCM = {
-                { Main.CONNECTORS.NOTUSED, Main.CONNECTORS.ANDD, Main.CONNECTORS.ORR },
-                { Main.CONNECTORS.ANDD, Main.CONNECTORS.NOTUSED, Main.CONNECTORS.ORR },
-                { Main.CONNECTORS.ORR, Main.CONNECTORS.ORR, Main.CONNECTORS.NOTUSED }
-        };
+                Main.CONNECTORS[][] LCM = {
+                                { Main.CONNECTORS.NOTUSED, Main.CONNECTORS.ANDD, Main.CONNECTORS.ORR },
+                                { Main.CONNECTORS.ANDD, Main.CONNECTORS.NOTUSED, Main.CONNECTORS.ORR },
+                                { Main.CONNECTORS.ORR, Main.CONNECTORS.ORR, Main.CONNECTORS.NOTUSED }
+                };
 
-        boolean[] CMV = { true, false, true };
+                boolean[] CMV = { true, false, true };
 
-        boolean[][] expected = {
-                { true, false, true },
-                { false, true, true },
-                { true, true, true }
-        };
+                boolean[][] expected = {
+                                { true, false, true },
+                                { false, true, true },
+                                { true, true, true }
+                };
 
-        assertArrayEquals(expected, Main.PUM(LCM, CMV));
-    }
+                assertArrayEquals(expected, Main.PUM(LCM, CMV));
+        }
 
-    @Test
-    public void testPUMWithANDConnectors() {
+        @Test
+        public void testPUMWithANDConnectors() {
 
-        Main.CONNECTORS[][] LCM = {
-                { Main.CONNECTORS.ANDD, Main.CONNECTORS.ANDD, Main.CONNECTORS.ANDD },
-                { Main.CONNECTORS.ANDD, Main.CONNECTORS.ANDD, Main.CONNECTORS.ANDD },
-                { Main.CONNECTORS.ANDD, Main.CONNECTORS.ANDD, Main.CONNECTORS.ANDD }
-        };
+                Main.CONNECTORS[][] LCM = {
+                                { Main.CONNECTORS.ANDD, Main.CONNECTORS.ANDD, Main.CONNECTORS.ANDD },
+                                { Main.CONNECTORS.ANDD, Main.CONNECTORS.ANDD, Main.CONNECTORS.ANDD },
+                                { Main.CONNECTORS.ANDD, Main.CONNECTORS.ANDD, Main.CONNECTORS.ANDD }
+                };
 
-        boolean[] CMV = { false, false, false };
+                boolean[] CMV = { false, false, false };
 
-        boolean[][] expected = {
-                { false, false, false },
-                { false, false, false },
-                { false, false, false }
-        };
+                boolean[][] expected = {
+                                { false, false, false },
+                                { false, false, false },
+                                { false, false, false }
+                };
 
-        assertArrayEquals(expected, Main.PUM(LCM, CMV));
-    }
+                assertArrayEquals(expected, Main.PUM(LCM, CMV));
+        }
+
+        @Test
+        public void testPUMIllegalArgument() {
+
+                Main.CONNECTORS[][] LCM = {
+                                { Main.CONNECTORS.ANDD, Main.CONNECTORS.ANDD, Main.CONNECTORS.ANDD },
+                                { Main.CONNECTORS.ANDD, Main.CONNECTORS.ANDD, Main.CONNECTORS.ANDD },
+                                { Main.CONNECTORS.ANDD, Main.CONNECTORS.ANDD, Main.CONNECTORS.ANDD }
+                };
+
+                boolean[] CMV = { false, false };
+
+                Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+                        Main.PUM(LCM, CMV);
+                });
+
+                String expected = "The LCM should be a n x n vector, where n is the length of CMV";
+                String message = exception.getMessage();
+
+                assertEquals(expected, message);
+        }
 }


### PR DESCRIPTION
Implemented so that the PUM method checks so that the LCM matrix is a n x n matrix, where n is the length of the CMV vector. This is connected to issue #26. Also added a unittest related to this, which is connected to issue #3.